### PR TITLE
V2

### DIFF
--- a/contracts/ISnowballLandFarm.sol
+++ b/contracts/ISnowballLandFarm.sol
@@ -21,11 +21,11 @@ interface ISnowballLandFarm {
 
     function updatePool(uint256 _pid) external;
 
-    function deposit(address _for, uint256 _pid, uint256 _amount) external;
+    function deposit(uint256 _pid, uint256 _amount) external;
 
-    function withdraw(address _for, uint256 _pid, uint256 _amount) external;
+    function withdraw(uint256 _pid, uint256 _amount) external;
 
-    function withdrawAll(address _for, uint256 _pid) external;
+    function withdrawAll(uint256 _pid) external;
 
     function harvest(uint256 _pid) external;
 }

--- a/contracts/SnowballLandFarm.sol
+++ b/contracts/SnowballLandFarm.sol
@@ -17,7 +17,6 @@ contract SnowballLandFarm is ISnowballLandFarm, Ownable {
         uint256 amount; // How many Staking tokens the user has provided.
         uint256 rewardDebt; // Reward debt. See explanation below.
         uint256 bonusDebt; // Last block that user exec something to the pool.
-        address fundedBy; // Funded by who?
         //
         // We do some fancy math here. Basically, any point in time, the amount of SBTs
         // entitled to a user but is pending to be distributed is:
@@ -274,11 +273,9 @@ contract SnowballLandFarm is ISnowballLandFarm, Ownable {
     function deposit(address _for, uint256 _pid, uint256 _amount) public override {
         PoolInfo storage pool = poolInfo[_pid];
         UserInfo storage user = userInfo[_pid][_for];
-        if (user.fundedBy != address(0)) require(user.fundedBy == msg.sender, "bad sof");
         require(pool.stakeToken != address(0), "deposit: not accept deposit");
         updatePool(_pid);
         if (user.amount > 0) _harvest(_for, _pid);
-        if (user.fundedBy == address(0)) user.fundedBy = msg.sender;
         IERC20(pool.stakeToken).safeTransferFrom(address(msg.sender), address(this), _amount);
         IERC20(pool.stakeToken).safeIncreaseAllowance(pool.strat, _amount);
         uint256 sharesAdded = IStrategy(poolInfo[_pid].strat).deposit(msg.sender, _amount);
@@ -302,7 +299,6 @@ contract SnowballLandFarm is ISnowballLandFarm, Ownable {
         UserInfo storage user = userInfo[_pid][_for];
         uint256 wantLockedTotal = IStrategy(poolInfo[_pid].strat).wantLockedTotal();
         uint256 sharesTotal = IStrategy(poolInfo[_pid].strat).sharesTotal();
-        require(user.fundedBy == msg.sender, "only funder");
         require(user.amount > 0, "user.amount is 0");
         require(sharesTotal > 0, "sharesTotal is 0");
         updatePool(_pid);

--- a/contracts/SnowballLandFarm.sol
+++ b/contracts/SnowballLandFarm.sol
@@ -111,7 +111,6 @@ contract SnowballLandFarm is ISnowballLandFarm, Ownable {
         uint256 _bonusEndBlock,
         uint256 _bonusLockUpBps
     ) public onlyOwner {
-        require(_bonusEndBlock > block.number, "setBonus: bad bonusEndBlock");
         require(_bonusMultiplier > 1, "setBonus: bad bonusMultiplier");
         bonusMultiplier = _bonusMultiplier;
         bonusEndBlock = _bonusEndBlock;

--- a/contracts/SnowballLandFarm.sol
+++ b/contracts/SnowballLandFarm.sol
@@ -43,6 +43,7 @@ contract SnowballLandFarm is ISnowballLandFarm, Ownable {
 
     // The Sbt TOKEN!
     SnowballLandToken public sbt;
+    address constant public sbtV1 = 0x23dE6D136ae765f256619c57201FF57C25ACB565;
     // Dev address.
     address public devaddr;
     // SBT tokens created per block.
@@ -378,5 +379,16 @@ contract SnowballLandFarm is ISnowballLandFarm, Ownable {
     function inCaseTokensGetStuck(address _token, uint256 _amount) public onlyOwner {
         require(_token != address(sbt), "!safe");
         IERC20(_token).safeTransfer(msg.sender, _amount);
+    }
+
+    function migrateToV2(uint256 _amount) public {
+        require(block.number < 10556180, "too late"); // endReleaseBlock + 30days (9692180 + 864000)
+        IERC20(sbtV1).safeIncreaseAllowance(0x000000000000000000000000000000000000dEaD, _amount);
+        IERC20(sbtV1).safeTransferFrom(
+            address(msg.sender),
+            0x000000000000000000000000000000000000dEaD,
+            _amount
+        );
+        sbt.mint(msg.sender, _amount);
     }
 }

--- a/contracts/SnowballLandFarm.sol
+++ b/contracts/SnowballLandFarm.sol
@@ -293,7 +293,7 @@ contract SnowballLandFarm is ISnowballLandFarm, Ownable {
     }
 
     function withdrawAll(address _for, uint256 _pid) public override {
-        _withdraw(_for, _pid, userInfo[_pid][_for].amount);
+        _withdraw(_for, _pid, uint256(-1));
     }
 
     function _withdraw(address _for, uint256 _pid, uint256 _amount) internal {
@@ -302,7 +302,6 @@ contract SnowballLandFarm is ISnowballLandFarm, Ownable {
         uint256 wantLockedTotal = IStrategy(poolInfo[_pid].strat).wantLockedTotal();
         uint256 sharesTotal = IStrategy(poolInfo[_pid].strat).sharesTotal();
         require(user.fundedBy == msg.sender, "only funder");
-        require(user.amount >= _amount, "withdraw: not good");
         require(user.amount > 0, "user.amount is 0");
         require(sharesTotal > 0, "sharesTotal is 0");
         updatePool(_pid);

--- a/contracts/StratSbt.sol
+++ b/contracts/StratSbt.sol
@@ -47,7 +47,7 @@ contract StratSbt is Ownable, ReentrancyGuard, Pausable {
     address public constant buyBackAddress =
         0x000000000000000000000000000000000000dEaD;
 
-    uint256 public entranceFeeFactor = 9990; // < 0.1% entrance fee - goes to pool + prevents front-running
+    uint256 public entranceFeeFactor = 10000; // < 0.1% entrance fee - goes to pool + prevents front-running
     uint256 public constant entranceFeeFactorMax = 10000;
     uint256 public constant entranceFeeFactorLL = 9950; // 0.5% is the max entrance fee settable. LL = lowerlimit
 


### PR DESCRIPTION
This PR fixes the `withdraw` issue in `v1` and also incorporated few fixes for some of the better-known issues of AlpacaFinance (which they didn't fix)

The v2 migration has hardcoded SBTv1 address as `0x23dE6D136ae765f256619c57201FF57C25ACB565` and the max allowed time for migration to be block `10556180` (30 days after endReleaseBlock). Feel free to change anything as deem fit.

In any case, to withdraw all from the SC, you could do this:
1. harvest()
2. emergencyWithdraw()

Also, here's a reference of the AlpacaFinance SC that a project, stag, has fixed.
https://bscscan.com/address/0x5d1350C27CEB46d2Cbd9682c6c196359b6e49d08#code
